### PR TITLE
Add dotenv support

### DIFF
--- a/kitchen-digitalocean.gemspec
+++ b/kitchen-digitalocean.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen', '~> 1.0'
   spec.add_dependency 'fog'
+  spec.add_dependency 'dotenv'
 
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rake'

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -22,6 +22,9 @@ require 'kitchen'
 require 'etc'
 require 'socket'
 
+require 'dotenv'
+Dotenv.load
+
 module Kitchen
   module Driver
     # Digital Ocean driver for Kitchen.


### PR DESCRIPTION
Exporting environmental variable each time is annoying for me. So, I want to use [dotenv](https://github.com/bkeepers/dotenv) for registering digitalocean keys. 
