### PR TITLE
Allow using a correctly name-scoped environment variable for ssh_key_ids...

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -60,7 +60,7 @@ module Kitchen
       end
 
       default_config :ssh_key_ids do |driver|
-        ENV['SSH_KEY_IDS']
+        ENV['DIGITALOCEAN_SSH_KEY_IDS'] || ENV['SSH_KEY_IDS']
       end
 
       required_config :digitalocean_client_id


### PR DESCRIPTION
This should be entirely backwards compatible, but allows keeping env vars in my shell a bit cleaner.
