### PR TITLE
Sanitize default names, limit to 63 chars

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -83,13 +83,21 @@ module Kitchen
         instance.platform.name
       end
 
+      # Generate what should be a unique server name up to 63 total chars
+      # Base name:    15
+      # Username:     15
+      # Hostname:     23
+      # Random string: 7
+      # Separators:    3
+      # ================
+      # Total:        63
       def default_name
-        # Generate what should be a unique server name
-        rand_str = Array.new(8) { rand(36).to_s(36) }.join
-        "#{instance.name}-"\
-        "#{Etc.getlogin.gsub('_', '-')}-"\
-        "#{rand_str}-"\
-        "#{Socket.gethostname}"
+        [
+          instance.name.gsub(/\W/, '')[0..14],
+          Etc.getlogin.gsub(/\W/, '')[0..14],
+          Socket.gethostname.gsub(/\W/, '')[0..22],
+          Array.new(7) { rand(36).to_s(36) }.join
+        ].join('-')
       end
 
       private

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -28,11 +28,12 @@ describe Kitchen::Driver::Digitalocean do
   let(:logger) { Logger.new(logged_output) }
   let(:config) { Hash.new }
   let(:state) { Hash.new }
+  let(:instance_name) { 'potatoes' }
   let(:platform_name) { 'ubuntu' }
 
   let(:instance) do
     double(
-      name: 'potatoes',
+      name: instance_name,
       logger: logger,
       to_str: 'instance',
       platform: double(name: platform_name)
@@ -247,14 +248,48 @@ describe Kitchen::Driver::Digitalocean do
   # end
 
   describe '#default_name' do
+    let(:login) { 'user' }
+    let(:hostname) { 'host' }
+
     before(:each) do
-      allow(Etc).to receive(:getlogin).and_return('user')
-      allow(Socket).to receive(:gethostname).and_return('host')
+      allow(Etc).to receive(:getlogin).and_return(login)
+      allow(Socket).to receive(:gethostname).and_return(hostname)
     end
 
     it 'generates a name' do
-      expect(driver.default_name).to match(
-        /^potatoes-user-(\S*)-host/)
+      expect(driver.default_name).to match(/^potatoes-user-host-(\S*)/)
+    end
+
+    context 'local node with a long hostname' do
+      let(:hostname) { 'ab.c' * 20 }
+
+      it 'limits the generated name to 63 characters' do
+        expect(driver.default_name.length).to be <= (63)
+      end
+    end
+
+    context 'node with a long hostname, username, and base name' do
+      let(:login) { 'abcd' * 20 }
+      let(:hostname) { 'efgh' * 20 }
+      let(:instance_name) { 'ijkl' * 20 }
+
+      it 'limits the generated name to 63 characters' do
+        expect(driver.default_name.length).to eq(63)
+      end
+    end
+
+    context 'a login and hostname with punctuation in them' do
+      let(:login) { 'some.u-se-r' }
+      let(:hostname) { 'a.host-name' }
+      let(:instance_name) { 'a.instance-name' }
+
+      it 'strips out the dots to prevent bad server names' do
+        expect(driver.default_name).to_not include('.')
+      end
+
+      it 'strips out all but the three hyphen separators' do
+        expect(driver.default_name.count('-')).to eq(3)
+      end
     end
   end
 end


### PR DESCRIPTION
I discovered today that CentOS 7 apparently shipped with [this bug](https://bugzilla.mindrot.org/show_bug.cgi?id=2239). Creating a CentOS 7 server in DigitalOcean with a name > 63 characters results in a server with broken SSH access (port 22 not even open).

This change ports over [all](https://github.com/test-kitchen/kitchen-openstack/pull/20) [the](https://github.com/test-kitchen/kitchen-openstack/pull/49) [changes](https://github.com/test-kitchen/kitchen-openstack/pull/50) that were made to kitchen-openstack to get around naming issues. Limits names to <= 63 characters and strips out potentially-problematic punctuation.
