### PR TITLE
properly split ssh key ids

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -116,7 +116,7 @@ module Kitchen
           region: config[:region],
           image: config[:image],
           size: config[:size],
-          ssh_keys: config[:ssh_key_ids].split(' '),
+          ssh_keys: config[:ssh_key_ids].split(/, ?/),
           private_networking: config[:private_networking],
           ipv6: config[:ipv6]
         )


### PR DESCRIPTION
This pull request is to adjust the way multiple ssh_keys_ids are to be split into a ruby list. I adjusted the code to match what the README says - assuming the README was the way this feature should work.

Without this PR, multiple ssh keys should be defined like so:

DIGITALOCEAN_SSH_KEY_IDS = "1234 4321"

After this PR it will do the right thing for both of these situations:

DIGITALOCEAN_SSH_KEY_IDS = "1234,4321"
DIGITALOCEAN_SSH_KEY_IDS = "1234, 4321"
