### PR TITLE
make sure there are no underscores in hostname

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -97,7 +97,7 @@ module Kitchen
           Etc.getlogin.gsub(/\W/, '')[0..14],
           Socket.gethostname.gsub(/\W/, '')[0..22],
           Array.new(7) { rand(36).to_s(36) }.join
-        ].join('-')
+        ].join('-').gsub(/_/, '-')
       end
 
       private


### PR DESCRIPTION
This PR fixes an issue where underscores could potentially sneak into the hostname causing failure during the creation of the droplet.
