### PR TITLE
Fix #34; make key IDs always a String

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -118,7 +118,7 @@ module Kitchen
           region: config[:region],
           image: config[:image],
           size: config[:size],
-          ssh_keys: config[:ssh_key_ids].split(/, ?/),
+          ssh_keys: config[:ssh_key_ids].to_s.split(/, ?/),
           private_networking: config[:private_networking],
           ipv6: config[:ipv6]
         )


### PR DESCRIPTION
If a single key ID is put in the YAML config, it's stored as a Fixnum, causing the split call to error out.
