### PR TITLE
SSH Debug notice added

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ of your keys, use something like to following command to get them from the digit
 curl -X GET https://api.digitalocean.com/v2/account/keys -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN"
 ```
 
+If anything ssh-related causes behavior like `kitchen converge` asking you for a password then the SSH command line can be displayed using `kitchen login -l debug`. It might happen that the created DO Droplet will be created with the correct SSHKey, but kitchen won't find it. In this case you can set the path to the keyfile on your machine within the .kitchen.yml file as following:
+
+```yaml
+
+driver:
+  name: digitalocean
+  region: ams1
+  ssh_key_ids: 123456
+  ssh_key: '~/.ssh/digitalocean' # <<<
+```
+
 Please refer to the [Getting Started Guide](http://kitchen.ci/) for any further documentation.
 
 # Default Configuration


### PR DESCRIPTION
This just drove me nuts:

I created the droplet using the following kitchen.yml section:

```yaml
driver:
  name: digitalocean
  region: ams2
  size: 1gb
  ipv6: true
  private_networking: true
  digitalocean_access_token: xxx
  ssh_key_ids: 123456
```

But he wouldn't find the frikkin sshkey. This was caused by a interfering ~/.ssh/config section (as after creation of the droplet the connection string will just contain the ip as a hostname). Thus https://github.com/test-kitchen/test-kitchen/blob/master/lib/kitchen/driver/ssh_base.rb#L121  might be worth mentioning if $thing goes south.