### PR TITLE
Add the ability to map well-known platforms to slugs

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -95,8 +95,11 @@ module Kitchen
         state.delete(:hostname)
       end
 
+      # This method attempts to fetch the platform from a list of well-known
+      # platform => slug mappings, and falls back to using just the platform as
+      # provided if it can't find a mapping.
       def default_image
-        instance.platform.name
+        platform_to_slug_mapping.fetch(instance.platform.name, instance.platform.name)
       end
 
       # Generate what should be a unique server name up to 63 total chars
@@ -160,6 +163,24 @@ module Kitchen
 
       def debug_client_config
         debug("digitalocean_api_key #{config[:digitalocean_access_token]}")
+      end
+
+      def platform_to_slug_mapping
+        {
+          "centos-5.10"  => "centos-5-8-x64",
+          "centos-6.5"   => "centos-6-5-x64",
+          "centos-7.0"   => "centos-7-0-x64",
+          "debian-6.0"   => "debian-6-0-x64",
+          "debian-7.0"   => "debian-7-0-x64",
+          "debian-8.1"   => "debian-8-x64",
+          "fedora-21"    => "fedora-21-x64",
+          "fedora-22"    => "fedora-22-x64",
+          "freebsd-10.1" => "freebsd-10-1-x64",
+          "ubuntu-12.04" => "ubuntu-12-04-x64",
+          "ubuntu-14.04" => "ubuntu-14-04-x64",
+          "ubuntu-14.10" => "ubuntu-14-10-x64",
+          "ubuntu-15.04" => "ubuntu-15-04-x64"
+        }
       end
     end
   end

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -99,7 +99,8 @@ module Kitchen
       # platform => slug mappings, and falls back to using just the platform as
       # provided if it can't find a mapping.
       def default_image
-        platform_to_slug_mapping.fetch(instance.platform.name, instance.platform.name)
+        platform_to_slug_mapping.fetch(instance.platform.name,
+                                       instance.platform.name)
       end
 
       # Generate what should be a unique server name up to 63 total chars
@@ -167,19 +168,19 @@ module Kitchen
 
       def platform_to_slug_mapping
         {
-          "centos-5.10"  => "centos-5-8-x64",
-          "centos-6.5"   => "centos-6-5-x64",
-          "centos-7.0"   => "centos-7-0-x64",
-          "debian-6.0"   => "debian-6-0-x64",
-          "debian-7.0"   => "debian-7-0-x64",
-          "debian-8.1"   => "debian-8-x64",
-          "fedora-21"    => "fedora-21-x64",
-          "fedora-22"    => "fedora-22-x64",
-          "freebsd-10.1" => "freebsd-10-1-x64",
-          "ubuntu-12.04" => "ubuntu-12-04-x64",
-          "ubuntu-14.04" => "ubuntu-14-04-x64",
-          "ubuntu-14.10" => "ubuntu-14-10-x64",
-          "ubuntu-15.04" => "ubuntu-15-04-x64"
+          'centos-5.10'  => 'centos-5-8-x64',
+          'centos-6.5'   => 'centos-6-5-x64',
+          'centos-7.0'   => 'centos-7-0-x64',
+          'debian-6.0'   => 'debian-6-0-x64',
+          'debian-7.0'   => 'debian-7-0-x64',
+          'debian-8.1'   => 'debian-8-x64',
+          'fedora-21'    => 'fedora-21-x64',
+          'fedora-22'    => 'fedora-22-x64',
+          'freebsd-10.1' => 'freebsd-10-1-x64',
+          'ubuntu-12.04' => 'ubuntu-12-04-x64',
+          'ubuntu-14.04' => 'ubuntu-14-04-x64',
+          'ubuntu-14.10' => 'ubuntu-14-10-x64',
+          'ubuntu-15.04' => 'ubuntu-15-04-x64'
         }
       end
     end

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -85,6 +85,14 @@ describe Kitchen::Driver::Digitalocean do
       end
     end
 
+    context 'platform name matches a known platform => slug mapping' do
+      let(:platform_name) { 'ubuntu-14.04' }
+
+      it 'defaults to the correct image ID' do
+        expect(driver[:image]).to eq('ubuntu-14-04-x64')
+      end
+    end
+
     context 'overridden options' do
       config = {
         image: 'debian-7-0-x64',

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -88,7 +88,7 @@ describe Kitchen::Driver::Digitalocean do
     context 'platform name matches a known platform => slug mapping' do
       let(:platform_name) { 'ubuntu-14.04' }
 
-      it 'defaults to the correct image ID' do
+      it 'matches the correct image slug' do
         expect(driver[:image]).to eq('ubuntu-14-04-x64')
       end
     end


### PR DESCRIPTION
This adds the ability to use well-known platform names in your `platforms` definition that you might use with other drivers (`kitchen-vagrant` for example) and map them to slugs that DigitalOcean uses.

Essentially, making it possible to do this:
```yml
platforms:
  - ubuntu-14.04
```
Instead of:
```yml
platforms:
  - ubuntu-14-04-x64
```
I personally switch between drivers quite a lot, and would really like to have the most common platforms conveniently available like this.

WDYT?