### PR TITLE
Fix deprecation warning around SimpleCov::Formatter::MultiFormatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,11 @@ require 'simplecov'
 require 'simplecov-console'
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   Coveralls::SimpleCov::Formatter,
   SimpleCov::Formatter::HTMLFormatter,
   SimpleCov::Formatter::Console
-]
+])
 SimpleCov.start
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
The following deprecation warning is displayed without this change:

```spec/spec_helper.rb:25:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.```