### PR TITLE
Bump droplet_kit to latest 2.0 series release

### DIFF
--- a/kitchen-digitalocean.gemspec
+++ b/kitchen-digitalocean.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '~> 1.2'
-  spec.add_dependency 'droplet_kit', '~> 1.0'
+  spec.add_dependency 'droplet_kit', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This relaxes the faraday dependency to allow it to work with ChefDK 2.0 and resolves #52 