### PR TITLE
Update image slugs for ubuntu 17, 18, fedora 27, 28

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -187,7 +187,8 @@ module Kitchen
           'freebsd-10.3'   => 'freebsd-10-3-x64-zfs',
           'ubuntu-14'   => 'ubuntu-14-04-x64',
           'ubuntu-16'   => 'ubuntu-16-04-x64',
-          'ubuntu-17'   => 'ubuntu-17-10-x64'
+          'ubuntu-17'   => 'ubuntu-17-10-x64',
+          'ubuntu-18'   => 'ubuntu-18-04-x64'
         }
       end
     end

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -180,15 +180,14 @@ module Kitchen
           'debian-7'     => 'debian-7-x64',
           'debian-8'     => 'debian-8-x64',
           'debian-9'     => 'debian-9-x64',
-          'fedora-24'      => 'fedora-24-x64',
-          'fedora-25'      => 'fedora-25-x64',
-          'fedora-26'      => 'fedora-26-x64',
+          'fedora-27'      => 'fedora-27-x64',
+          'fedora-28'      => 'fedora-28-x64',
           'freebsd-11.1'   => 'freebsd-11-1-x64-zfs',
           'freebsd-11.0'   => 'freebsd-11-0-x64-zfs',
           'freebsd-10.3'   => 'freebsd-10-3-x64-zfs',
           'ubuntu-14'   => 'ubuntu-14-04-x64',
           'ubuntu-16'   => 'ubuntu-16-04-x64',
-          'ubuntu-17'   => 'ubuntu-17-04-x64'
+          'ubuntu-17'   => 'ubuntu-17-10-x64'
         }
       end
     end

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -89,7 +89,7 @@ describe Kitchen::Driver::Digitalocean do
       let(:platform_name) { 'ubuntu-17' }
 
       it 'matches the correct image slug' do
-        expect(driver[:image]).to eq('ubuntu-17-04-x64')
+        expect(driver[:image]).to eq('ubuntu-17-10-x64')
       end
     end
 


### PR DESCRIPTION
update library to match DO current public image list;

- Adding ubuntu 18
- fixing ubuntu-17 to match available slug
- removing fedora 24,25,26
- adding fedora 27,28

```
[~] $ doctl compute image list-distribution --public | grep ubuntu
34264495    17.10 x64            snapshot    Ubuntu           ubuntu-17-10-x64        true      20
34594793    16.04.4 x32          snapshot    Ubuntu           ubuntu-16-04-x32        true      20
34628116    14.04.5 x64          snapshot    Ubuntu           ubuntu-14-04-x64        true      20
34629350    14.04.5 x32          snapshot    Ubuntu           ubuntu-14-04-x32        true      20
34629387    18.04 x64            snapshot    Ubuntu           ubuntu-18-04-x64        true      20
35103451    16.04.4 x64          snapshot    Ubuntu           ubuntu-16-04-x64        true      20
[~] $ doctl compute image list-distribution --public | grep fedora
29492039    27 x64               snapshot    Fedora           fedora-27-x64           true      20
33948356    28 x64               snapshot    Fedora           fedora-28-x64           true      20
34114584    28 x64 Atomic        snapshot    Fedora Atomic    fedora-28-x64-atomic    true      20
```

