### PR TITLE
Add firewalls attribute to driver config

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ coreos-alpha
 debian-7
 debian-8
 debian-9
-fedora-24
-fedora-25
-fedora-26
+fedora-27
+fedora-28
 reebsd-11.1
 freebsd-11.0
 freebsd-10.3
 ubuntu-14
 ubuntu-16
 ubuntu-17
+ubuntu-18
 ```
 
 # Regions
@@ -144,6 +144,32 @@ tor1    Toronto 1
 sfo2    San Francisco 2
 blr1    Bangalore 1
 ```
+
+# Firewall
+
+To create the droplet with firewalls, provide a pre-existing firewall ID as a
+string or list of string
+
+```ruby
+driver:
+  firewalls:
+    - 7a489167-a3d5-4d93-9f4a-371bd02ea8a3
+    - 624c1408-f101-4b59-af64-99c7f7560f7a
+```
+or
+```ruby
+driver:
+  firewalls: 624c1408-f101-4b59-af64-99c7f7560f7a
+```
+
+Note that your `firewalls` must be the numeric ids of your firewall. To get the 
+numeric ID, use something like to following command to get them from the digital 
+ocean API:
+
+```bash
+curl -X GET https://api.digitalocean.com/v2/firewalls -H "Authorization: Bearer $DIGITALOCEAN_ACCESS_TOKEN"
+```
+
 
 # Development
 

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -1,5 +1,3 @@
-# -*- encoding: utf-8 -*-
-
 #
 # Author:: Greg Fitzgerald (<greg@gregf.org>)
 #
@@ -78,15 +76,15 @@ module Kitchen
                    elsif config[:firewalls].is_a?(Array)
                      config[:firewalls]
                    else
-                    warn('firewalls attribute is not string or array, ignoring')
-                    []
+                     warn('firewalls attribute is not string/array, ignoring')
+                     []
                    end
           debug("firewall : #{fw_ids.inspect.to_yaml}")
           fw_ids.each do |fw_id|
             firewall = client.firewalls.find(id: fw_id)
             if firewall
               client.firewalls
-                      .add_droplets([droplet.id], id: firewall.id)
+                    .add_droplets([droplet.id], id: firewall.id)
               debug("firewall added: #{firewall.id}")
             else
               warn("firewalls id: '#{fw_id}' was not found in api, ignoring")

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 #
 # Author:: Greg Fitzgerald (<greg@gregf.org>)
 #

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -39,6 +39,7 @@ module Kitchen
       default_config :private_networking, true
       default_config :ipv6, false
       default_config :user_data, nil
+      default_config :firewalls, nil
 
       default_config :digitalocean_access_token do
         ENV['DIGITALOCEAN_ACCESS_TOKEN']
@@ -69,6 +70,29 @@ module Kitchen
 
         state[:hostname] = droplet.networks[:v4]
                                   .find { |n| n[:type] == 'public' }['ip_address']
+
+        if config[:firewalls]
+          debug('trying to add the firewall by id')
+          fw_ids = if config[:firewalls].is_a?(String)
+                     config[:firewalls].split(/\s+|,\s+|,+/)
+                   elsif config[:firewalls].is_a?(Array)
+                     config[:firewalls]
+                   else
+                    warn('firewalls attribute is not string or array, ignoring')
+                    []
+                   end
+          debug("firewall : #{fw_ids.inspect.to_yaml}")
+          fw_ids.each do |fw_id|
+            firewall = client.firewalls.find(id: fw_id)
+            if firewall
+              client.firewalls
+                      .add_droplets([droplet.id], id: firewall.id)
+              debug("firewall added: #{firewall.id}")
+            else
+              warn("firewalls id: '#{fw_id}' was not found in api, ignoring")
+            end
+          end
+        end
 
         wait_for_sshd(state[:hostname]); print "(ssh ready)\n"
         debug("digitalocean:create #{state[:hostname]}")
@@ -164,6 +188,7 @@ module Kitchen
         debug("digitalocean:private_networking #{config[:private_networking]}")
         debug("digitalocean:ipv6 #{config[:ipv6]}")
         debug("digitalocean:user_data #{config[:user_data]}")
+        debug("digitalocean:firewalls #{config[:firewalls]}")
       end
 
       def debug_client_config


### PR DESCRIPTION
This patch adds a `firewalls` attribute to the driver config.

 1. allows creating droplets in one or more firewalls.
 2. updated the README.md

can be used like so;


```ruby
driver:
  name: digitalocean
  size: s-2vcpu-4gb
  region: lon1
  firewalls:
    - 9a3d91e2-b44d-4117-8031-0c9f518845a2
    - 663f789c-3f40-4308-bb2f-a37ac39e27c4
```

will create an instance with those two firewalls attached to the droplet;
```shell
$ doctl compute firewall list-by-droplet -o json  ${id} | jq '.[] | .name,.id'
"test-fw-2"
"663f789c-3f40-4308-bb2f-a37ac39e27c4"
"test-fw-1"
"9a3d91e2-b44d-4117-8031-0c9f518845a2"
```