### PR TITLE
add tags attribute to the driver config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ sfo2    San Francisco 2
 blr1    Bangalore 1
 ```
 
+
+# Tags
+
+To add tags to the droplet, provide the tags attribute
+
+```ruby
+driver:
+  tags:
+    - test-kitchen
+    - this-is-a-tag
+```
+
+
 # Firewall
 
 To create the droplet with firewalls, provide a pre-existing firewall ID as a

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -39,6 +39,7 @@ module Kitchen
       default_config :private_networking, true
       default_config :ipv6, false
       default_config :user_data, nil
+      default_config :tags, nil
       default_config :firewalls, nil
 
       default_config :digitalocean_access_token do
@@ -166,7 +167,12 @@ module Kitchen
           ssh_keys: config[:ssh_key_ids].to_s.split(/, ?/),
           private_networking: config[:private_networking],
           ipv6: config[:ipv6],
-          user_data: config[:user_data]
+          user_data: config[:user_data],
+          tags: if config[:tags].is_a?(String)
+                  config[:tags].split(/\s+|,\s+|,+/)
+                else
+                  config[:tags]
+                end
         )
 
         resp = client.droplets.create(droplet)
@@ -188,6 +194,7 @@ module Kitchen
         debug("digitalocean:private_networking #{config[:private_networking]}")
         debug("digitalocean:ipv6 #{config[:ipv6]}")
         debug("digitalocean:user_data #{config[:user_data]}")
+        debug("digitalocean:tags #{config[:tags]}")
         debug("digitalocean:firewalls #{config[:firewalls]}")
       end
 


### PR DESCRIPTION
This patch adds support for tags attribute like so;

```
driver:
  name: digitalocean
  tags:
    - do_test_pool
    - tagXXX
```

results in a droplet with the following tags;

```
$ doctl compute droplet get 97568706 --format ID,Tags
ID          Tags
97568706    do_test_pool,tagXXX
```