### PR TITLE
feature: default region environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,49 @@ platforms:
   - name: ubuntu-17
 ```
 
+By default your droplets will be built in `nyc1` but you can change the default by updating the
+environment variable.
+
+```bash
+export DIGITALOCEAN_REGION="tor1"
+```
+
+This allows futher customization by allowing overrides at the `driver` level and the `platform`
+level.
+
+```ruby
+# DIGITALOCEAN_REGION="tor1" # set as an env var
+
+# cookbook1/.kitchen.yml
+---
+driver:
+  name: digitalocean
+  region: sgp1
+platforms:
+  - name: ubuntu-16
+  - name: ubuntu-18
+    region: sfo1
+
+# cookbook2/.kitchen.yml
+---
+driver:
+  name: digitalocean
+platforms:
+  - name: ubuntu-16
+  - name: ubuntu-18
+    region: sfo1
+```
+
+The above configuration when full tested would create the following images in their respective
+regions
+
+|Image|Region|
+|---|---|
+|cookbook1-ubuntu-16|sgp1|
+|cookbook1-ubuntu-18|sfo1|
+|cookbook2-ubuntu-16|tor1|
+|cookbook2-ubuntu-18|sfo1|
+
 You also have the option of providing your credentials from environment variables.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,49 +48,6 @@ platforms:
   - name: ubuntu-17
 ```
 
-By default your droplets will be built in `nyc1` but you can change the default by updating the
-environment variable.
-
-```bash
-export DIGITALOCEAN_REGION="tor1"
-```
-
-This allows futher customization by allowing overrides at the `driver` level and the `platform`
-level.
-
-```ruby
-# DIGITALOCEAN_REGION="tor1" # set as an env var
-
-# cookbook1/.kitchen.yml
----
-driver:
-  name: digitalocean
-  region: sgp1
-platforms:
-  - name: ubuntu-16
-  - name: ubuntu-18
-    region: sfo1
-
-# cookbook2/.kitchen.yml
----
-driver:
-  name: digitalocean
-platforms:
-  - name: ubuntu-16
-  - name: ubuntu-18
-    region: sfo1
-```
-
-The above configuration when full tested would create the following images in their respective
-regions
-
-|Image|Region|
-|---|---|
-|cookbook1-ubuntu-16|sgp1|
-|cookbook1-ubuntu-18|sfo1|
-|cookbook2-ubuntu-16|tor1|
-|cookbook2-ubuntu-18|sfo1|
-
 You also have the option of providing your credentials from environment variables.
 
 ```bash
@@ -185,6 +142,50 @@ tor1    Toronto 1
 sfo2    San Francisco 2
 blr1    Bangalore 1
 ```
+
+By default your droplets will be built in `nyc1` but you can change the default by updating the
+environment variable.  This should allow teams with developers across different regions to test within
+their own geographic region without hard coding configs.
+
+```bash
+export DIGITALOCEAN_REGION="tor1"
+```
+
+This allows futher customization by allowing overrides at the `driver` level and the `platform`
+level.
+
+```ruby
+# DIGITALOCEAN_REGION="tor1" # set as an env var
+
+# cookbook1/.kitchen.yml
+---
+driver:
+  name: digitalocean
+  region: sgp1
+platforms:
+  - name: ubuntu-16
+  - name: ubuntu-18
+    region: sfo1
+
+# cookbook2/.kitchen.yml
+---
+driver:
+  name: digitalocean
+platforms:
+  - name: ubuntu-16
+  - name: ubuntu-18
+    region: sfo1
+```
+
+The above configuration when full tested would create the following images in their respective
+regions.
+
+|Image|Region|
+|---|---|
+|cookbook1-ubuntu-16|sgp1|
+|cookbook1-ubuntu-18|sfo1|
+|cookbook2-ubuntu-16|tor1|
+|cookbook2-ubuntu-18|sfo1|
 
 # Tags
 

--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -30,7 +30,6 @@ module Kitchen
     class Digitalocean < Kitchen::Driver::SSHBase
       default_config :username, 'root'
       default_config :port, '22'
-      default_config :region, 'nyc1'
       default_config :size, '512mb'
       default_config :monitoring, false
       default_config(:image, &:default_image)
@@ -40,6 +39,10 @@ module Kitchen
       default_config :user_data, nil
       default_config :tags, nil
       default_config :firewalls, nil
+
+      default_config :region do
+        ENV['DIGITALOCEAN_REGION'] || 'nyc1'
+      end
 
       default_config :digitalocean_access_token do
         ENV['DIGITALOCEAN_ACCESS_TOKEN']

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -76,6 +76,17 @@ describe Kitchen::Driver::Digitalocean do
       end
     end
 
+    context 'DIGITALOCEAN_REGION is tor1' do
+      before(:each) do
+        allow_any_instance_of(described_class).to receive(:instance)
+          .and_return(instance)
+        ENV['DIGITALOCEAN_REGION'] = 'tor1'
+      end
+      it 'defaults to region from DIGITALOCEAN_REGION' do
+        expect(driver[:region]).to eq('tor1')
+      end
+    end
+
     context 'name is ubuntu-14-04-x64' do
       let(:platform_name) { 'ubuntu-14-04-x64' }
 


### PR DESCRIPTION
This feature allows you to switch out the default hard coded region.  Simple, yet effective, allowing you to keep a unified kitchen config for your cookbooks but have your developers test in their local DC. 