### PR TITLE
Update default size to 1GB

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -32,7 +32,7 @@ module Kitchen
     class Digitalocean < Kitchen::Driver::SSHBase
       default_config :username, 'root'
       default_config :port, '22'
-      default_config :size, '512mb'
+      default_config :size, '1gb'
       default_config :monitoring, false
       default_config(:image, &:default_image)
       default_config(:server_name, &:default_name)

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -51,7 +51,7 @@ describe Kitchen::Driver::Digitalocean do
   describe '#initialize' do
     context 'default options' do
       it 'defaults to the smallest size' do
-        expect(driver[:size]).to eq('512mb')
+        expect(driver[:size]).to eq('1gb')
       end
 
       it 'defaults to SSH with root user on port 22' do

--- a/spec/mocks/create.txt
+++ b/spec/mocks/create.txt
@@ -19,7 +19,7 @@ CF-RAY: 15dabd6d78ac00af-EWR
   "droplet":{
     "id":"1234",
     "name":"test-1234",
-    "memory":512,
+    "memory":1024,
     "vcpus":1,
     "disk":20,
     "region":{
@@ -89,7 +89,7 @@ CF-RAY: 15dabd6d78ac00af-EWR
       ]
     },
     "size":{
-      "slug":"512mb",
+      "slug":"1gb",
       "transfer":1,
       "price_monthly":5.0,
       "price_hourly":0.00744

--- a/spec/mocks/find.txt
+++ b/spec/mocks/find.txt
@@ -21,7 +21,7 @@ CF-RAY: 1e90fbb7d41b0707-SJC
   "droplet": {
     "id": 1234,
     "name": "test-droplet",
-    "memory": 512,
+    "memory": 1024,
     "vcpus": 1,
     "disk": 20,
     "locked": false,
@@ -50,8 +50,8 @@ CF-RAY: 1e90fbb7d41b0707-SJC
       "type": "snapshot"
     },
     "size": {
-      "slug": "512mb",
-      "memory": 512,
+      "slug": "1gb",
+      "memory": 1024,
       "vcpus": 1,
       "disk": 20,
       "transfer": 1.0,
@@ -60,7 +60,7 @@ CF-RAY: 1e90fbb7d41b0707-SJC
       "regions": ["nyc1", "sgp1", "ams1", "sfo1", "nyc2", "lon1", "nyc3", "ams3", "ams2", "fra1"],
       "available": true
     },
-    "size_slug": "512mb",
+    "size_slug": "1gb",
     "networks": {
       "v4": [{
         "ip_address": "45.55.141.244",


### PR DESCRIPTION
DigitalOcean minimum droplet size is 1GB. 512MB is still available via API. However, you pay the same price per hour for a 1gb droplet.