### PR TITLE
Optimize our requires

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -17,12 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'benchmark'
-require 'droplet_kit'
+require 'benchmark' unless defined?(Benchmark)
+require 'droplet_kit' unless defined?(DropletKit)
 require 'kitchen'
-require 'etc'
-require 'socket'
-require 'json'
+require 'etc' unless defined?(Etc)
+require 'socket' unless defined?(Socket)
+require 'json' unless defined?(JSON)
 
 module Kitchen
   module Driver

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -18,7 +18,7 @@
 require_relative '../../spec_helper'
 
 require 'logger'
-require 'stringio'
+require 'stringio' unless defined?(StringIO)
 require 'rspec'
 require 'kitchen'
 


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>