### PR TITLE
driver/digitalocean: update default slug to match API

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -33,7 +33,7 @@ module Kitchen
     class Digitalocean < Kitchen::Driver::SSHBase
       default_config :username, 'root'
       default_config :port, '22'
-      default_config :size, '1gb'
+      default_config :size, 's-1vcpu-1gb'
       default_config :monitoring, false
       default_config(:image, &:default_image)
       default_config(:server_name, &:default_name)

--- a/spec/kitchen/driver/digitalocean_spec.rb
+++ b/spec/kitchen/driver/digitalocean_spec.rb
@@ -51,7 +51,7 @@ describe Kitchen::Driver::Digitalocean do
   describe '#initialize' do
     context 'default options' do
       it 'defaults to the smallest size' do
-        expect(driver[:size]).to eq('1gb')
+        expect(driver[:size]).to eq('s-1vcpu-1gb')
       end
 
       it 'defaults to SSH with root user on port 22' do


### PR DESCRIPTION
https://slugs.do-api.dev/ refers to the new names.

# Description

The default size currently is a deprecated slug name.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
