### PR TITLE
add slug for debian 11

### DIFF
--- a/lib/kitchen/driver/digitalocean.rb
+++ b/lib/kitchen/driver/digitalocean.rb
@@ -64,6 +64,7 @@ module Kitchen
         "centos-8" => "centos-8-x64",
         "debian-9" => "debian-9-x64",
         "debian-10" => "debian-10-x64",
+        "debian-11" => "debian-11-x64",
         "fedora-32" => "fedora-32-x64",
         "fedora-33" => "fedora-33-x64",
         "freebsd-11" => "freebsd-11-x64-zfs",


### PR DESCRIPTION
# Description

Add slug for debian 11 distro image.

## Issues Resolved

Allows `debian-11` image name to be used in your kitchen configuration.
